### PR TITLE
[extract_srt_subtitles_to_files] 0.0.12

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 
+**<span style="color:#56adda">0.0.12</span>**
+- add back in file test check for presence of text subtitles
+- change text of what is written in .unmanic file to prevent against empty string in cases where remove all subtitles is run in same library
+
 **<span style="color:#56adda">0.0.11</span>**
 - remove note in description.md about plugin not having a file test section - a file test section was added in v0.0.8
 

--- a/info.json
+++ b/info.json
@@ -15,5 +15,5 @@
         "on_worker_process": 2
     },
     "tags": "subtitle,ffmpeg",
-    "version": "0.0.11"
+    "version": "0.0.12"
 }

--- a/plugin.py
+++ b/plugin.py
@@ -220,12 +220,15 @@ def on_library_management_file_test(data):
     mapper.set_settings(settings)
     mapper.set_probe(probe)
 
-    if not srt_already_extracted(settings, abspath):
-        # Mark this file to be added to the pending tasks
-        data['add_file_to_pending_tasks'] = True
-        logger.debug("File '{}' should be added to task list. File has not been previously had SRT extracted.".format(abspath))
+    if mapper.streams_need_processing():
+        if not srt_already_extracted(settings, abspath):
+            # Mark this file to be added to the pending tasks
+            data['add_file_to_pending_tasks'] = True
+            logger.debug("File '{}' should be added to task list. File has text subtitles that have not previously been extract to SRT files.".format(abspath))
+        else:
+            logger.debug("File '{}' has previously had text subtitles extracted as SRT files.".format(abspath))
     else:
-        logger.debug("File '{}' has been previously had SRT extracted.".format(abspath))                           
+        logger.debug("File '{}' does not contain streams require processing.".format(abspath))
 
     return data
 
@@ -349,7 +352,7 @@ def on_postprocessor_task_results(data):
                 subs = [i for i in subs if i in langs]
             subs = ' '.join(subs)
         else:
-            subs=""
+            subs="true"
         directory_info = UnmanicDirectoryInfo(os.path.dirname(destination_file))
         directory_info.set('extract_srt_subtitles_to_files', os.path.basename(destination_file), subs)
         directory_info.save()


### PR DESCRIPTION
repair plugin's file test which removed the test for the presence of text subtitles when the plugin was last modified to add the use of the .unmanic file.  now the file test correctly tests for presence of text subtitles AND whether or not the file has already had text subtitles previously extracted.

Also fixes a corner case in the post processor that writes the .unmanic file - it collects the subtitle streams found in the file and writes them as a string into the .unmanic file.  in the case where the library also contains the remove all subtitles  plugin, the file no longer has any subtitles by the time the post processor is run and so the string gets written as "".  this causes the file test of whether the plugin previously extracted text subtitles to fail.